### PR TITLE
Issue fix: Exceptions are not being handled #6

### DIFF
--- a/src/Middleware/RestApiMiddleware.php
+++ b/src/Middleware/RestApiMiddleware.php
@@ -35,7 +35,7 @@ class RestApiMiddleware extends ErrorHandlerMiddleware
                 $className = App::className($controllerName, 'Controller', 'Controller');
                 $controller = ($className) ? new $className() : null;
                 if ($controller && 'RestApi\Controller\ApiController' === get_parent_class($controller)) {
-                    $this->renderer = 'RestApi\Error\ApiExceptionRenderer';
+                    $this->exceptionRenderer = 'RestApi\Error\ApiExceptionRenderer';
                     EventManager::instance()->on(new ApiRequestHandler());
                 }
                 unset($controller);


### PR DESCRIPTION
Found a bug where wrong variable was set on RestApiMiddleware class. Instead of $this->renderer, $this->expcetionRenderer must be set. Maybe a cakephp 3.x version update.