### PR TITLE
Adding support for prefix routing (e.g. /api/users/profile)

### DIFF
--- a/src/Middleware/RestApiMiddleware.php
+++ b/src/Middleware/RestApiMiddleware.php
@@ -5,6 +5,7 @@ namespace RestApi\Middleware;
 use Cake\Core\App;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Event\EventManager;
+use Cake\Utility\Inflector;
 use RestApi\Event\ApiRequestHandler;
 
 class RestApiMiddleware extends ErrorHandlerMiddleware
@@ -32,7 +33,12 @@ class RestApiMiddleware extends ErrorHandlerMiddleware
                 ) {
                     return $next($request, $response);
                 }
-                $className = App::className($controllerName, 'Controller', 'Controller');
+                $type = 'Controller';
+                if(isset($params['prefix']) && $params['prefix']) {
+                    $prefix = Inflector::camelize($params['prefix']);
+                    $type = 'Controller/'.$prefix;
+                }
+                $className = App::className($controllerName, $type, 'Controller');
                 $controller = ($className) ? new $className() : null;
                 if ($controller && 'RestApi\Controller\ApiController' === get_parent_class($controller)) {
                     if (isset($this->renderer)) {

--- a/src/Middleware/RestApiMiddleware.php
+++ b/src/Middleware/RestApiMiddleware.php
@@ -34,7 +34,7 @@ class RestApiMiddleware extends ErrorHandlerMiddleware
                     return $next($request, $response);
                 }
                 $type = 'Controller';
-                if(isset($params['prefix']) && $params['prefix']) {
+                if (isset($params['prefix']) && $params['prefix']) {
                     $prefix = Inflector::camelize($params['prefix']);
                     $type = 'Controller/'.$prefix;
                 }

--- a/src/Middleware/RestApiMiddleware.php
+++ b/src/Middleware/RestApiMiddleware.php
@@ -36,7 +36,7 @@ class RestApiMiddleware extends ErrorHandlerMiddleware
                 $type = 'Controller';
                 if (isset($params['prefix']) && $params['prefix']) {
                     $prefix = Inflector::camelize($params['prefix']);
-                    $type = 'Controller/'.$prefix;
+                    $type = 'Controller/' . $prefix;
                 }
                 $className = App::className($controllerName, $type, 'Controller');
                 $controller = ($className) ? new $className() : null;


### PR DESCRIPTION
I want to use a prefix (e.g. /api/users/profile) for the API access point, but I noticed that error and exception pages do not work if I used a prefix, which is because of the following line in the middleware:

`$className = App::className($controllerName, 'Controller', 'Controller');`

The prefix would need to be appended to the second argument, like this:

`$className = App::className($controllerName, 'Controller/Api', 'Controller');`

assuming that your controller for the API is /src/Controller/Api/UsersController.php

I tested this locally and worked, but I don't know how to add this to your unit test thing.