### PR TITLE
Allow responseType other than json & xml

### DIFF
--- a/src/Event/ApiRequestHandler.php
+++ b/src/Event/ApiRequestHandler.php
@@ -100,10 +100,11 @@ class ApiRequestHandler implements EventListenerInterface
         $request = $event->data['request'];
         $response = $event->data['response'];
 
-        if ('xml' === Configure::read('ApiRequest.responseType')) {
-            $response->type('xml');
-        } else {
-            $response->type('json');
+        $responseType = Configure::read('ApiRequest.responseType');
+        if ('xml' === $responseType) {
+            $response = $response->withType('xml');
+        } else if ('json' === $responseType) {
+            $response = $response->withType('json');
         }
 
         $response->cors($request)


### PR DESCRIPTION
Let CakePHP determine response type if other than configured (json/xml). This allows setting ApiRequest.responseType to false/null to let CakePHP handle setting the response type, such as for streaming a binary file from the api.