### PR TITLE
Check for subclass of ApiController

### DIFF
--- a/src/Middleware/RestApiMiddleware.php
+++ b/src/Middleware/RestApiMiddleware.php
@@ -40,7 +40,7 @@ class RestApiMiddleware extends ErrorHandlerMiddleware
                 }
                 $className = App::className($controllerName, $type, 'Controller');
                 $controller = ($className) ? new $className() : null;
-                if ($controller && 'RestApi\Controller\ApiController' === get_parent_class($controller)) {
+                if( $controller && is_a($controller, 'RestApi\Controller\ApiController', TRUE)) {
                     if (isset($this->renderer)) {
                         $this->renderer = 'RestApi\Error\ApiExceptionRenderer';
                     } else {

--- a/src/Middleware/RestApiMiddleware.php
+++ b/src/Middleware/RestApiMiddleware.php
@@ -40,7 +40,7 @@ class RestApiMiddleware extends ErrorHandlerMiddleware
                 }
                 $className = App::className($controllerName, $type, 'Controller');
                 $controller = ($className) ? new $className() : null;
-                if( $controller && is_a($controller, 'RestApi\Controller\ApiController', TRUE)) {
+                if( $controller && is_subclass_of($controller, 'RestApi\Controller\ApiController')) {
                     if (isset($this->renderer)) {
                         $this->renderer = 'RestApi\Error\ApiExceptionRenderer';
                     } else {

--- a/src/Middleware/RestApiMiddleware.php
+++ b/src/Middleware/RestApiMiddleware.php
@@ -40,7 +40,7 @@ class RestApiMiddleware extends ErrorHandlerMiddleware
                 }
                 $className = App::className($controllerName, $type, 'Controller');
                 $controller = ($className) ? new $className() : null;
-                if( $controller && is_subclass_of($controller, 'RestApi\Controller\ApiController')) {
+                if ($controller && is_subclass_of($controller, 'RestApi\Controller\ApiController')) {
                     if (isset($this->renderer)) {
                         $this->renderer = 'RestApi\Error\ApiExceptionRenderer';
                     } else {


### PR DESCRIPTION
I've got a use case where I've subclassed ApiController so that all my Api Controllers can then be derived from a class with some common functions.

In order to allow this your middleware needs to check that ApiController is somewhere in the inheritance tree of the current controller, rather than specifically its parent class.  I've used the PHP is_subclass_of function (PHP >= 4).