### PR TITLE
Access Cake\Http\Response  as object in ApiErrorController

### DIFF
--- a/src/Controller/ApiErrorController.php
+++ b/src/Controller/ApiErrorController.php
@@ -28,7 +28,7 @@ class ApiErrorController extends AppController
         if (Configure::read('ApiRequest.debug') && isset($this->viewVars['error'])) {
             $this->apiResponse[$this->responseFormat['messageKey']] = $this->viewVars['error']->getMessage();
         } else {
-            $this->apiResponse[$this->responseFormat['messageKey']] = !empty($messageArr[$this->httpStatusCode]) ? $messageArr[$this->httpStatusCode] : 'Unknown error!';
+            $this->apiResponse[$this->responseFormat['messageKey']] = !empty($messageArr->body) ? $messageArr->body : 'Unknown error!';
         }
 
         Configure::write('apiExceptionMessage', isset($this->viewVars['error']) ? $this->viewVars['error']->getMessage() : null);


### PR DESCRIPTION
Fix for issue #40 